### PR TITLE
Fix typo in `transititivereduction`

### DIFF
--- a/src/digraph/transitivity.jl
+++ b/src/digraph/transitivity.jl
@@ -154,7 +154,7 @@ julia> collect(edges(transitivereduction(barbell)))
  Edge 6 => 4
 ```
 """
-function transitivereducion end
+function transitivereduction end
 @traitfn function transitivereduction(g::::IsDirected; selflooped::Bool=false)
     scc = strongly_connected_components(g)
     cg = condensation(g, scc)


### PR DESCRIPTION
The "body-less" definition that is used for the index in the docs was typed as `transitivereducion` (without second `t`). No breaking change, though, since the exported function is correctly named.